### PR TITLE
add test and deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,3 +25,4 @@ jobs:
 
     - name: Push
       run: docker push ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Build and Publish Container Image
+
+on:
+  push:
+    tags: [v*.*.*]
+
+jobs:
+  build:
+    name: Build + Push
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Get version
+      run: echo "IMAGE_TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+    - name: Build Docker Image
+      run: docker build -t ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG} .
+    
+    - name: Login
+      run: docker login -u publisher -p ${GHCR_TOKEN} ghcr.io
+      env:
+        GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+
+    - name: Push
+      run: docker push ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test Build Container Image
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Get version
+      run: echo "IMAGE_TAG=${GITHUB_ACTOR}" >> $GITHUB_ENV
+
+    - name: Build Docker Image
+      run: docker build -t ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG} .
+
+    - name: Run Docker Image
+      run: docker run -it -d --rm -p 5000:5000 ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}
+
+    - name: Test Docker Image
+      run: curl "http://localhost:5000/indicators?exchange=binance&symbol=BTC/USDT&interval=1h"
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 ``sudo docker run -it --rm -p 5000:5000 indicators``
 
+or
+
+``sudo docker run -it --rm -p 5000:5000 ghcr.io/breim/TAlib-altcoins-api:X.X.X``
+
 **Get indicators**
 
 http://localhost:5000/indicators?exchange=binance&symbol=BTC/USDT&interval=1h


### PR DESCRIPTION
Hey, I love this project!

I was looking for a way to centrally host the image, and rather than fork the code and add it to my own registry I thought you might like to add it to yours.

The test workflow builds the image and tests it using the curl call from your readme.

Once you merge it to master, you just need to create a release with the format `vX.X.X` eg: `v1.0.0` and then people will be able to pull it down using `docker pull ghcr.io/breim/TAlib-altcoins-api:1.0.0 ` for example.

When you make your first version, you will have to go to your profile, packages, and set the image to be "public" so people can pull it down.

Let me know what you think!