### PR TITLE
use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,7 @@ jobs:
       run: docker build -t ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG} .
     
     - name: Login
-      run: docker login -u publisher -p ${GHCR_TOKEN} ghcr.io
-      env:
-        GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      run: docker login -u publisher -p ${GITHUB_TOKEN} ghcr.io
 
     - name: Push
       run: docker push ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}


### PR DESCRIPTION
the built-in GITHUB_TOKEN env should be able to publish packages now.